### PR TITLE
Update applet.js

### DIFF
--- a/bettersettings@bownz/files/bettersettings@bownz/applet.js
+++ b/bettersettings@bownz/files/bettersettings@bownz/applet.js
@@ -123,7 +123,7 @@ MyApplet.prototype = {
             });
 
 	    this.menu.addAction(_("Start up Applications"), function(event) {
-                Util.spawnCommandLine("gnome-session-properties");
+                Util.spawnCommandLine("cinnamon-settings startup");
             });
 
             this.menu.addAction(_("Cinnamon Settings"), function(event) {


### PR DESCRIPTION
use cinnamons startup manager instead of needing user to find and install gnome-session-mager.